### PR TITLE
Add Auto-Release Cleanup to CI

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -46,7 +46,7 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d %H:%M:%S %Z')" >> $GITHUB_OUTPUT
       - name: Get Short Commit Hash for Nightly Versioning
         id: commithash
-        run: echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "hash=$(date +'%Y%m%d%H%M')" >> $GITHUB_OUTPUT
 
   build-win:
     name: Build Executable (Windows)
@@ -194,6 +194,13 @@ jobs:
           --output ./publish
           -p:VersionPrefix=${{ vars.VERSION_PREFIX }}
           -p:VersionSuffix=nightly-${{ needs.get-info.outputs.hash }}
+      - name: Delete Older Prerelease Package Versions
+        uses: actions/delete-package-versions@v4.1.1
+        with:
+          ignore-versions: '^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'
+          package-name: RetireSimple.Engine
+          package-type: nuget
+          min-versions-to-keep: 0
       - name: Push NuGet Package
         run: dotnet nuget push ./publish/RetireSimple.Engine.*.nupkg
           --source "https://nuget.pkg.github.com/RetireSimple/index.json"
@@ -310,11 +317,18 @@ jobs:
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v3
-      - name: Nightly
+      - name: Delete Older Releases
+        uses: dev-drprasad/delete-older-releases@v0.2.1
+        with:
+          delete_tags: true
+          delete_tag_pattern: "nightly"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Nightly - ${{ vars.VERSION_PREFIX }}-nightly-${{ needs.get-info.outputs.hash }
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: nightly-${{ needs.get-info.outputs.hash }}
+          tag: ${{ vars.VERSION_PREFIX }}-nightly-${{ needs.get-info.outputs.hash }}
           name: Nightly
           allowUpdates: true
           draft: false


### PR DESCRIPTION
## What type of PR is this?

Other

## What does this PR Add/Change/Remove?

Adds automatic cleanup of nightly releases in the Nightly Builder pipeline, for both GH releases + packages. Also changes the nightly version scheme to use a datestring rather than commit hash to guarantee some form of chronological sorting

## Is this PR Related to an Issue? If so, indicate which issue(s) it closes.

N/A

## Are there any important notes for reviewers?

N/A